### PR TITLE
Use f64 for weight, not i32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v1.0.1 - 2025-01-13
+
+Internal refactoring.
+
+This fixes a theoretically possible but statistically unlikely bug where `randline` could return less than *k* items, even when there were less than *k* items in the input.
+
 ## v1.0.0 - 2025-01-11
 
 Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "randline"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "assert_cmd",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "randline"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
This fixes a theoretically possible but statistically unlikely bug where `randline` could return less than *k* items, even when there were less than *k* items in the input.

In particular, by using a `HashMap` that's keyed by weight, if you have two items with the same weight, one of them will silently be dropped when you insert the second item!

Using a proper binary heap should fix this, and allow item with the same weight (although that's also less likely with f64).

Closes #3